### PR TITLE
Fix warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,17 +18,17 @@ macro_rules! strenum {
                     _ => None
                 }
             }
-            
+
             fn stringify() -> String {
                 let mut buf = Vec::<String>::new();
                 let mut n: u8 = 0;
-                
+
                 while let Some(val) = <Self>::from_u8(n) {
                     buf.push(format!("{:?}", val));
                     n += 1;
                 }
-                
-                buf.connect("\n")
+
+                buf.join("\n")
             }
         }
     }
@@ -56,4 +56,3 @@ fn enumify() {
         testenum::a => panic!("Got a instead of b"),
     };
 }
-


### PR DESCRIPTION
`connect` has been renamed to `join`. I'm not sure if you want to merge this as it will probably then be broken in the stable build.
